### PR TITLE
Chore:Update Interactive Text

### DIFF
--- a/src/me/Cutiemango/MangoQuest/book/InteractiveText.java
+++ b/src/me/Cutiemango/MangoQuest/book/InteractiveText.java
@@ -1,5 +1,8 @@
 package me.Cutiemango.MangoQuest.book;
 
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
 import me.Cutiemango.MangoQuest.data.QuestPlayerData;
 import me.Cutiemango.MangoQuest.manager.QuestChatManager;
 import me.Cutiemango.MangoQuest.model.Quest;
@@ -8,8 +11,6 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
-import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.NotNull;
 
 public class InteractiveText
 {
@@ -23,10 +24,13 @@ public class InteractiveText
 
 	// similar to showItem
 	public InteractiveText(@NotNull ItemStack item) {
+		
+		//if(!this.getClass().isAssignableFrom(ItemSafeInteractiveText.class)) {
 		text = TextComponentFactory.convertItemHoverEvent(item, false);
+		//}
 	}
 
-	private TextComponent text;
+	protected TextComponent text;
 
 	// "/" needed.
 	public InteractiveText clickCommand(String cmd) {


### PR DESCRIPTION
### ISSUE
- The quest names and descriptions automatically indents when there are large chunk of space vacated

### SOLUTION
- increase max_char_per_line variable such that more space can be consumed